### PR TITLE
Add basic multiplayer framework and emoji identities

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -1,22 +1,69 @@
-// Basic client setup connecting to the WebSocket server
+import { Block } from './pieces.js';
+
+// WebSocket connection to the server
 const socket = new WebSocket(`ws://${location.host}`);
 
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
+
+let myEmoji = '❓';
+let pieces = [];
+let sideView = false;
 
 socket.addEventListener('open', () => {
     console.log('Connected to server');
 });
 
 socket.addEventListener('message', event => {
-    // Handle incoming messages (game state updates, etc.)
-    console.log('Server:', event.data);
+    const msg = JSON.parse(event.data);
+    switch (msg.type) {
+        case 'welcome':
+            myEmoji = msg.emoji;
+            pieces = msg.pieces || [];
+            break;
+        case 'addPiece':
+            pieces.push(msg.piece);
+            break;
+        case 'playerJoined':
+            console.log(`${msg.emoji} joined`);
+            break;
+        case 'playerLeft':
+            console.log(`${msg.emoji} left`);
+            break;
+    }
 });
 
-// Placeholder render loop
+canvas.addEventListener('click', (e) => {
+    const rect = canvas.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const piece = new Block(Date.now(), x, y);
+    pieces.push(piece);
+    socket.send(JSON.stringify({ type: 'addPiece', piece }));
+});
+
+window.addEventListener('keydown', (e) => {
+    if (e.key === 'v') {
+        sideView = !sideView;
+    }
+});
+
+function drawPieces() {
+    ctx.fillStyle = sideView ? '#4aa' : '#333';
+    pieces.forEach(p => {
+        ctx.fillRect(p.x - 10, p.y - 10, 20, 20);
+    });
+}
+
 function render() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    // Draw game objects here
+    drawPieces();
+
+    // Display current player's emoji
+    ctx.font = '24px sans-serif';
+    ctx.fillStyle = '#000';
+    ctx.fillText(myEmoji, 10, 30);
+
     requestAnimationFrame(render);
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,9 @@
 </head>
 <body>
     <canvas id="gameCanvas" width="800" height="600"></canvas>
-    <script src="client.js"></script>
+    <div style="position:absolute;top:10px;right:10px;color:#333;font-family:sans-serif;font-size:14px;">
+        Click to add a block. Press 'v' to toggle view.
+    </div>
+    <script type="module" src="client.js"></script>
 </body>
 </html>

--- a/public/pieces.js
+++ b/public/pieces.js
@@ -1,0 +1,8 @@
+export class Block {
+    constructor(id, x, y) {
+        this.id = id;
+        this.type = 'block';
+        this.x = x;
+        this.y = y;
+    }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -2,24 +2,66 @@ const express = require('express');
 const { createServer } = require('http');
 const { WebSocketServer } = require('ws');
 const path = require('path');
+const crypto = require('crypto');
 
 const app = express();
 const httpServer = createServer(app);
 const wss = new WebSocketServer({ server: httpServer });
 const PORT = process.env.PORT || 3000;
 
+// In-memory storage for connected players and puzzle pieces
+const emojiList = ['😀', '😎', '😂', '🤖', '🦄', '🐱', '🐶', '🐸', '🐵', '🐼', '🐧', '🐰'];
+const players = new Map();
+const puzzlePieces = [];
+
+function emojiForIP(ip) {
+  // Simple hash to map an IP to one of the emojis
+  const hash = crypto.createHash('md5').update(ip).digest()[0];
+  return emojiList[hash % emojiList.length];
+}
+
 app.use(express.static(path.join(__dirname, '../public')));
 
-wss.on('connection', (ws) => {
-  console.log('Client connected');
+// Broadcast helper
+function broadcast(obj) {
+  const msg = JSON.stringify(obj);
+  wss.clients.forEach(client => {
+    if (client.readyState === client.OPEN) {
+      client.send(msg);
+    }
+  });
+}
 
-  ws.on('message', (data) => {
-    // Broadcast messages to all connected clients
-    wss.clients.forEach((client) => {
-      if (client.readyState === ws.OPEN) {
-        client.send(data);
-      }
-    });
+wss.on('connection', (ws, req) => {
+  const ip = req.socket.remoteAddress || '0.0.0.0';
+  const emoji = emojiForIP(ip);
+
+  players.set(ws, { ip, emoji });
+
+  // Send existing puzzle state and assigned emoji to the new player
+  ws.send(JSON.stringify({ type: 'welcome', emoji, pieces: puzzlePieces }));
+
+  // Notify others a player joined
+  broadcast({ type: 'playerJoined', emoji });
+
+  ws.on('message', (message) => {
+    let data;
+    try {
+      data = JSON.parse(message);
+    } catch (e) {
+      return;
+    }
+
+    // Update puzzle state and broadcast actions
+    if (data.type === 'addPiece') {
+      puzzlePieces.push(data.piece);
+      broadcast({ type: 'addPiece', piece: data.piece });
+    }
+  });
+
+  ws.on('close', () => {
+    players.delete(ws);
+    broadcast({ type: 'playerLeft', emoji });
   });
 });
 


### PR DESCRIPTION
## Summary
- implement in-memory player tracking and emoji assignment on the server
- broadcast puzzle pieces across clients
- add client-side game loop with ability to add blocks
- provide view toggle instruction and module scripts
- introduce basic `Block` piece class

## Testing
- `npm start` *(fails: cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden while fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_685ad47ae5cc832fbeb7e7f4135803e9