### PR TITLE
Add simple audio effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Emoji Goldberg Puzzle is a multiplayer collaborative puzzle game inspired by Rub
 - **Colorful 2D art** with smooth animations and whimsical effects.
 - **Real-time multiplayer** with synchronized updates so everyone stays on the same page.
 - **Scaling difficulty** to keep new and experienced players engaged.
+- **Sound effects and background music** for a more playful experience.
 
 ## Visual and Animation Quality
 - Assets should be crisp and modern, using a consistent palette with complementary colors.

--- a/TODO.md
+++ b/TODO.md
@@ -22,3 +22,4 @@ r.~~ Added tests for WebSocket welcome and UI toggling.
 - ~~Allow players to move or delete pieces they've placed for better collaboration.~~ Added drag and double-click controls with server enforcement.
 - ~~Track puzzle completion counts in a persistent leaderboard displayed on the client.~~ Leaderboard now sent on welcome and puzzle completion.
 - ~~Add a spring piece that launches the ball upward when triggered.~~ Added Spring piece with physics and drawing.
+- ~~Sound effects and background music.~~ Added oscillator-based audio in the client.

--- a/public/client.js
+++ b/public/client.js
@@ -1,5 +1,6 @@
 import { Block, Ramp, Ball, Fan, Spring, pieceAlpha } from './ui.js';
 import { updateBall } from './physics.js';
+import { playBeep, startBackgroundMusic } from './sound.js';
 
 // WebSocket connection to the server
 const socket = new WebSocket(`ws://${location.host}`);
@@ -35,6 +36,7 @@ function pieceAt(x, y) {
 
 socket.addEventListener('open', () => {
     console.log('Connected to server');
+    startBackgroundMusic();
 });
 
 socket.addEventListener('message', event => {
@@ -54,6 +56,7 @@ socket.addEventListener('message', event => {
             break;
         case 'addPiece':
             pieces.push(msg.piece);
+            playBeep();
             break;
         case 'movePiece': {
             const p = pieces.find(p => p.id === msg.id);
@@ -62,6 +65,7 @@ socket.addEventListener('message', event => {
         }
         case 'removePiece':
             pieces = pieces.filter(p => p.id !== msg.id);
+            playBeep(330);
             break;
         case 'ballUpdate':
             if (ball && msg.ball.id === ball.id) {
@@ -124,6 +128,7 @@ canvas.addEventListener('mousedown', (e) => {
         piece.owner = myEmoji;
         pieces.push(piece);
         socket.send(JSON.stringify({ type: 'addPiece', piece }));
+        playBeep();
     }
 });
 
@@ -154,6 +159,7 @@ canvas.addEventListener('contextmenu', (e) => {
     piece.owner = myEmoji;
     pieces.push(piece);
     socket.send(JSON.stringify({ type: 'addPiece', piece }));
+    playBeep();
 });
 
 canvas.addEventListener('auxclick', (e) => {
@@ -165,6 +171,7 @@ canvas.addEventListener('auxclick', (e) => {
     piece.owner = myEmoji;
     pieces.push(piece);
     socket.send(JSON.stringify({ type: 'addPiece', piece }));
+    playBeep();
 });
 
 canvas.addEventListener('dblclick', (e) => {
@@ -175,6 +182,7 @@ canvas.addEventListener('dblclick', (e) => {
     if (p && p.owner === myEmoji) {
         pieces = pieces.filter(q => q.id !== p.id);
         socket.send(JSON.stringify({ type: 'removePiece', id: p.id }));
+        playBeep(330);
     }
 });
 

--- a/public/sound.js
+++ b/public/sound.js
@@ -1,0 +1,32 @@
+export const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+
+export function playBeep(freq = 440, duration = 0.1, volume = 0.1) {
+    const osc = audioCtx.createOscillator();
+    const gain = audioCtx.createGain();
+    osc.type = 'sine';
+    osc.frequency.value = freq;
+    gain.gain.value = volume;
+    osc.connect(gain);
+    gain.connect(audioCtx.destination);
+    osc.start();
+    osc.stop(audioCtx.currentTime + duration);
+}
+
+export function startBackgroundMusic() {
+    const notes = [261.63, 329.63, 392.0, 523.25];
+    let idx = 0;
+    setInterval(() => {
+        const freq = notes[idx % notes.length];
+        const osc = audioCtx.createOscillator();
+        const gain = audioCtx.createGain();
+        osc.type = 'sine';
+        osc.frequency.value = freq;
+        gain.gain.setValueAtTime(0.05, audioCtx.currentTime);
+        gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.4);
+        osc.connect(gain);
+        gain.connect(audioCtx.destination);
+        osc.start();
+        osc.stop(audioCtx.currentTime + 0.4);
+        idx++;
+    }, 400);
+}


### PR DESCRIPTION
## Summary
- add a small sound module with beep and looping background notes
- update the client to play beeps when pieces are added or removed
- start simple background music on connection
- note the audio feature in README and TODO

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b52ededf0832f9ffd3fde28cc9f2f