### PR TITLE
Add palette with rotate handle

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -14,6 +14,8 @@ const leaderboardEl = document.getElementById('leaderboard');
 const resetLevelBtn = document.getElementById('resetLevelBtn');
 const emojiInput = document.getElementById('emojiInput');
 const emojiBtn = document.getElementById('emojiBtn');
+const palette = document.getElementById('palette');
+const rotateBtn = document.getElementById('rotateBtn');
 
 const otherCursors = new Map();
 let draggingPiece = null;
@@ -41,10 +43,34 @@ if (emojiBtn && emojiInput) {
     });
 }
 
+if (palette) {
+    palette.addEventListener('click', (e) => {
+        const item = e.target.closest('.palette-item');
+        if (!item) return;
+        selectedType = item.dataset.type;
+        if (item.dataset.direction) {
+            selectedDirection = item.dataset.direction;
+        }
+    });
+}
+
+if (rotateBtn) {
+    rotateBtn.addEventListener('click', () => {
+        selectedDirection = selectedDirection === 'right' ? 'left' : 'right';
+        const rampItem = document.getElementById('rampItem');
+        if (rampItem) {
+            rampItem.dataset.direction = selectedDirection;
+            rampItem.textContent = selectedDirection === 'right' ? 'Ramp ▶' : 'Ramp ◀';
+        }
+    });
+}
+
 let myEmoji = '❓';
 let pieces = [];
 let target = null;
 let ball = null;
+let selectedType = 'block';
+let selectedDirection = 'right';
 
 function pieceAt(x, y) {
     return pieces.find(p => {
@@ -161,7 +187,16 @@ canvas.addEventListener('mousedown', (e) => {
             dragOffset.y = y - targetPiece.y;
             return;
         }
-        const piece = e.shiftKey ? new Spring(Date.now(), x, y, 8) : new Block(Date.now(), x, y);
+        let piece;
+        if (selectedType === 'ramp') {
+            piece = new Ramp(Date.now(), x, y, selectedDirection);
+        } else if (selectedType === 'fan') {
+            piece = new Fan(Date.now(), x, y, 1);
+        } else if (selectedType === 'spring') {
+            piece = new Spring(Date.now(), x, y, 8);
+        } else {
+            piece = e.shiftKey ? new Spring(Date.now(), x, y, 8) : new Block(Date.now(), x, y);
+        }
         piece.owner = myEmoji;
         pieces.push(piece);
         socket.send(JSON.stringify({ type: 'addPiece', piece }));
@@ -192,7 +227,16 @@ canvas.addEventListener('touchstart', (e) => {
         dragOffset.x = x - targetPiece.x;
         dragOffset.y = y - targetPiece.y;
     } else {
-        const piece = new Block(Date.now(), x, y);
+        let piece;
+        if (selectedType === 'ramp') {
+            piece = new Ramp(Date.now(), x, y, selectedDirection);
+        } else if (selectedType === 'fan') {
+            piece = new Fan(Date.now(), x, y, 1);
+        } else if (selectedType === 'spring') {
+            piece = new Spring(Date.now(), x, y, 8);
+        } else {
+            piece = new Block(Date.now(), x, y);
+        }
         piece.owner = myEmoji;
         pieces.push(piece);
         socket.send(JSON.stringify({ type: 'addPiece', piece }));

--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,13 @@
         <div id="leaderboard"></div>
         <div id="chatLog"></div>
         <input id="chatInput" type="text" placeholder="Type a message" />
+        <div id="palette">
+            <div class="palette-item" data-type="block">Block</div>
+            <div id="rampItem" class="palette-item" data-type="ramp" data-direction="right">Ramp ▶</div>
+            <button id="rotateBtn">↺ Rotate</button>
+            <div class="palette-item" data-type="fan">Fan</div>
+            <div class="palette-item" data-type="spring">Spring</div>
+        </div>
         <div id="controls">Click to add a block. Press 'r' for a new puzzle.
             <button id="resetLevelBtn">Reset Level</button>
         </div>

--- a/public/style.css
+++ b/public/style.css
@@ -73,6 +73,33 @@ header {
     pointer-events: auto;
 }
 
+#palette {
+    position: absolute;
+    top: 60px;
+    right: 140px;
+    background: rgba(0,0,0,0.5);
+    padding: 8px;
+    border-radius: 4px;
+    pointer-events: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 14px;
+}
+
+.palette-item {
+    background: rgba(255,255,255,0.1);
+    padding: 4px 6px;
+    border-radius: 4px;
+    cursor: pointer;
+    user-select: none;
+}
+
+#rotateBtn {
+    margin-top: 4px;
+    cursor: pointer;
+}
+
 #resetLevelBtn {
     margin-left: 8px;
 }


### PR DESCRIPTION
## Summary
- add a docked piece palette UI
- support selecting piece type and rotating ramps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dae02f3ec832f8790e45bccfad35c