### PR TITLE
Enable deterministic level regeneration by seed

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -26,7 +26,7 @@ r.~~ Added tests for WebSocket welcome and UI toggling.
 - ~~Responsive layout and touch controls.~~ Canvas now resizes and supports taps.
 
 ## Next work items
-- Rewrite generator using a three-phase algorithm starting from `levelGenerator.js`.
+- ~~Rewrite generator using a three-phase algorithm starting from `levelGenerator.js`.~~ Implemented phased generator with golden path, Poisson disk fill and barriers.
  - ~~Add Poisson-disk spacing utility (`minDistancePx`).~~ Implemented in `server/levelGenerator.js`.
 - ~~Create a headless solver worker returning `solutionPath` and `difficultyScore`; cache by seed.~~ Implemented in `server/solver.js`.
 - Unit tests:
@@ -39,6 +39,6 @@ r.~~ Added tests for WebSocket welcome and UI toggling.
  - One-way gate and Magnet with new force calculations.
 - Keyboard shortcuts with focus ring and a skip-able tutorial.
 - Settings modal for audio slider and color-blind palette toggle.
-- Broadcast only the seed so clients regenerate levels and persist per-emoji scores and fastest solves.
+- ~~Broadcast only the seed so clients regenerate levels and persist per-emoji scores and fastest solves.~~ Implemented deterministic level regeneration.
 - Add victory confetti tweens, mobile haptics on goal collision and overall ghost replay polish.
 - CI must lint, run tests and solve a level in under 500 ms, plus a smoke test verifying multiplayer sync.

--- a/public/client.js
+++ b/public/client.js
@@ -1,6 +1,7 @@
 import { Block, Ramp, Ball, Fan, Spring, Wall, pieceAlpha, setupResponsiveCanvas } from './ui.js';
 import { updateBall } from './physics.js';
 import { playBeep, startBackgroundMusic } from './sound.js';
+import { generatePuzzle } from './levelGenerator.js';
 
 // WebSocket connection to the server
 const socket = new WebSocket(`ws://${location.host}`);
@@ -137,9 +138,16 @@ socket.addEventListener('message', event => {
     switch (msg.type) {
         case 'welcome':
             myEmoji = msg.emoji;
-            pieces = (msg.pieces || []).filter(p => p.type !== 'ball');
-            ball = (msg.pieces || []).find(p => p.type === 'ball') || null;
-            target = msg.target;
+            if (msg.seed) {
+                const puzzle = generatePuzzle(msg.difficulty, msg.seed);
+                pieces = puzzle.pieces.filter(p => p.type !== 'ball');
+                ball = puzzle.pieces.find(p => p.type === 'ball') || null;
+                target = puzzle.target;
+            } else {
+                pieces = (msg.pieces || []).filter(p => p.type !== 'ball');
+                ball = (msg.pieces || []).find(p => p.type === 'ball') || null;
+                target = msg.target;
+            }
             puzzleStartTime = Date.now();
             resets = 0;
             updateHud();
@@ -192,9 +200,16 @@ socket.addEventListener('message', event => {
             pieces = [];
             ball = null;
             target = null;
-            pieces = (msg.pieces || []).filter(p => p.type !== 'ball');
-            ball = (msg.pieces || []).find(p => p.type === 'ball') || null;
-            target = msg.target;
+            if (msg.seed) {
+                const puzzle = generatePuzzle(msg.difficulty, msg.seed);
+                pieces = puzzle.pieces.filter(p => p.type !== 'ball');
+                ball = puzzle.pieces.find(p => p.type === 'ball') || null;
+                target = puzzle.target;
+            } else {
+                pieces = (msg.pieces || []).filter(p => p.type !== 'ball');
+                ball = (msg.pieces || []).find(p => p.type === 'ball') || null;
+                target = msg.target;
+            }
             resets = 0;
             puzzleStartTime = Date.now();
             updateHud();

--- a/server/server.js
+++ b/server/server.js
@@ -89,8 +89,8 @@ wss.on('connection', (ws, req) => {
   ws.send(JSON.stringify({
     type: 'welcome',
     emoji,
-    pieces: puzzleState.pieces,
-    target: puzzleState.target,
+    seed: puzzleState.seed,
+    difficulty: puzzleState.difficulty,
     leaderboard: db.progress || {}
   }));
 
@@ -125,7 +125,7 @@ wss.on('connection', (ws, req) => {
         });
         initialPuzzleState = JSON.parse(JSON.stringify(puzzleState));
         broadcastLeaderboard();
-        broadcast({ type: 'newPuzzle', pieces: puzzleState.pieces, target: puzzleState.target });
+        broadcast({ type: 'newPuzzle', seed: puzzleState.seed, difficulty: puzzleState.difficulty });
       } else {
         db.puzzleState = puzzleState;
         saveDB(db);
@@ -150,7 +150,7 @@ wss.on('connection', (ws, req) => {
         });
         initialPuzzleState = JSON.parse(JSON.stringify(puzzleState));
         broadcastLeaderboard();
-        broadcast({ type: 'newPuzzle', pieces: puzzleState.pieces, target: puzzleState.target });
+        broadcast({ type: 'newPuzzle', seed: puzzleState.seed, difficulty: puzzleState.difficulty });
       } else {
         db.puzzleState = puzzleState;
         saveDB(db);
@@ -205,12 +205,12 @@ wss.on('connection', (ws, req) => {
         saveDB(db);
       });
       initialPuzzleState = JSON.parse(JSON.stringify(puzzleState));
-      broadcast({ type: 'newPuzzle', pieces: puzzleState.pieces, target: puzzleState.target });
+      broadcast({ type: 'newPuzzle', seed: puzzleState.seed, difficulty: puzzleState.difficulty });
     } else if (data.type === 'resetLevel') {
       // restore puzzle to its original state without changing difficulty
       puzzleState = db.puzzleState = JSON.parse(JSON.stringify(initialPuzzleState));
       saveDB(db);
-      broadcast({ type: 'newPuzzle', pieces: puzzleState.pieces, target: puzzleState.target });
+      broadcast({ type: 'newPuzzle', seed: puzzleState.seed, difficulty: puzzleState.difficulty });
     }
   });
 


### PR DESCRIPTION
## Summary
- keep level generator deterministic via a simple seeded RNG
- share generator with the browser so clients rebuild puzzles from a seed
- broadcast only the puzzle seed and difficulty
- update tests for seeded regeneration
- check off the TODO for broadcasting only the seed

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685dc89efe70832fb6fde4b9bf3992dd