### PR TITLE
Add settings modal with audio/color-blind options

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -38,7 +38,7 @@ r.~~ Added tests for WebSocket welcome and UI toggling.
  - ~~Static wall obstacle piece.~~ Implemented in codebase.
  - One-way gate and Magnet with new force calculations.
 - ~~Keyboard shortcuts with focus ring and a skip-able tutorial.~~ Added keydown controls, focus outlines and a dismissible tutorial overlay.
-- Settings modal for audio slider and color-blind palette toggle.
+ - ~~Settings modal for audio slider and color-blind palette toggle.~~ Added modal with volume slider and color-blind palette toggle.
 - ~~Broadcast only the seed so clients regenerate levels and persist per-emoji scores and fastest solves.~~ Implemented deterministic level regeneration.
 - Add victory confetti tweens, mobile haptics on goal collision and overall ghost replay polish.
 - CI must lint, run tests and solve a level in under 500 ms, plus a smoke test verifying multiplayer sync.

--- a/public/client.js
+++ b/public/client.js
@@ -1,6 +1,6 @@
 import { Block, Ramp, Ball, Fan, Spring, Wall, pieceAlpha, setupResponsiveCanvas } from './ui.js';
 import { updateBall } from './physics.js';
-import { playBeep, startBackgroundMusic } from './sound.js';
+import { playBeep, startBackgroundMusic, setMasterVolume, masterVolume } from './sound.js';
 import { generatePuzzle } from './levelGenerator.js';
 
 // WebSocket connection to the server
@@ -21,10 +21,37 @@ const palette = document.getElementById('palette');
 const rotateBtn = document.getElementById('rotateBtn');
 const tutorialEl = document.getElementById('tutorial');
 const skipTutorialBtn = document.getElementById('skipTutorialBtn');
+const settingsBtn = document.getElementById('settingsBtn');
+const settingsModal = document.getElementById('settingsModal');
+const closeSettingsBtn = document.getElementById('closeSettingsBtn');
+const volumeSlider = document.getElementById('volumeSlider');
+const colorBlindToggle = document.getElementById('colorBlindToggle');
 
 const otherCursors = new Map();
 let draggingPiece = null;
 let dragOffset = { x: 0, y: 0 };
+
+const normalPalette = {
+    block: '#4aa',
+    ramp: '#aa4',
+    fan: '#88c',
+    spring: '#090',
+    wall: '#844',
+    ball: '#f90',
+    target: '#e33'
+};
+
+const cbPalette = {
+    block: '#377eb8',
+    ramp: '#984ea3',
+    fan: '#4daf4a',
+    spring: '#e41a1c',
+    wall: '#ff7f00',
+    ball: '#ffff33',
+    target: '#a65628'
+};
+
+let paletteColors = normalPalette;
 
 chatInput.addEventListener('keydown', (e) => {
     if (e.key === 'Enter' && chatInput.value.trim() !== '') {
@@ -76,6 +103,30 @@ if (skipTutorialBtn) {
     skipTutorialBtn.addEventListener('click', () => {
         tutorialEl.classList.add('hidden');
         canvas.focus();
+    });
+}
+
+if (settingsBtn && settingsModal && closeSettingsBtn) {
+    settingsBtn.addEventListener('click', () => {
+        settingsModal.classList.remove('hidden');
+        if (volumeSlider) volumeSlider.value = masterVolume;
+        if (colorBlindToggle) colorBlindToggle.checked = paletteColors === cbPalette;
+    });
+    closeSettingsBtn.addEventListener('click', () => {
+        settingsModal.classList.add('hidden');
+        canvas.focus();
+    });
+}
+
+if (volumeSlider) {
+    volumeSlider.addEventListener('input', () => {
+        setMasterVolume(parseFloat(volumeSlider.value));
+    });
+}
+
+if (colorBlindToggle) {
+    colorBlindToggle.addEventListener('change', () => {
+        paletteColors = colorBlindToggle.checked ? cbPalette : normalPalette;
     });
 }
 
@@ -448,7 +499,7 @@ window.addEventListener('keydown', (e) => {
 function drawBlock(p) {
     ctx.save();
     ctx.globalAlpha = pieceAlpha(p);
-    ctx.fillStyle = '#4aa';
+    ctx.fillStyle = paletteColors.block;
     // draw centered on p.x, p.y so physics & UI coordinates match
     ctx.fillRect(p.x - 10, p.y - 10, 20, 20);
     ctx.fillStyle = 'rgba(0,0,0,0.2)';
@@ -459,7 +510,7 @@ function drawBlock(p) {
 function drawRamp(p) {
     ctx.save();
     ctx.globalAlpha = pieceAlpha(p);
-    ctx.fillStyle = '#aa4';
+    ctx.fillStyle = paletteColors.ramp;
     ctx.beginPath();
     if (p.direction === 'right') {
         ctx.moveTo(p.x - 10, p.y + 10);
@@ -481,12 +532,12 @@ function drawRamp(p) {
 function drawFan(p) {
     ctx.save();
     ctx.globalAlpha = pieceAlpha(p);
-    ctx.fillStyle = '#88c';
+    ctx.fillStyle = paletteColors.fan;
     ctx.beginPath();
     ctx.arc(p.x, p.y, 10, 0, Math.PI * 2);
     ctx.moveTo(p.x, p.y);
     ctx.lineTo(p.x, p.y - 15);
-    ctx.strokeStyle = '#88c';
+    ctx.strokeStyle = paletteColors.fan;
     ctx.stroke();
     ctx.fill();
     ctx.restore();
@@ -495,7 +546,7 @@ function drawFan(p) {
 function drawSpring(p) {
     ctx.save();
     ctx.globalAlpha = pieceAlpha(p);
-    ctx.strokeStyle = '#090';
+    ctx.strokeStyle = paletteColors.spring;
     ctx.beginPath();
     ctx.arc(p.x, p.y, 10, 0, Math.PI * 2);
     ctx.moveTo(p.x - 6, p.y + 6);
@@ -519,7 +570,7 @@ function drawRotateHandle(p) {
 function drawWall(p) {
     ctx.save();
     ctx.globalAlpha = pieceAlpha(p);
-    ctx.fillStyle = '#844';
+    ctx.fillStyle = paletteColors.wall;
     ctx.fillRect(p.x - p.width / 2, p.y - p.height / 2, p.width, p.height);
     ctx.fillStyle = 'rgba(0,0,0,0.2)';
     ctx.fillRect(p.x - p.width / 2, p.y + p.height / 2, p.width, 5);
@@ -528,7 +579,7 @@ function drawWall(p) {
 
 function drawTarget() {
     if (!target) return;
-    ctx.fillStyle = '#e33';
+    ctx.fillStyle = paletteColors.target;
     ctx.beginPath();
     ctx.arc(target.x, target.y, 8, 0, Math.PI * 2);
     ctx.fill();
@@ -554,7 +605,7 @@ function drawBallPiece() {
     if (!ball) return;
     ctx.save();
     ctx.globalAlpha = pieceAlpha(ball);
-    ctx.fillStyle = '#f90';
+    ctx.fillStyle = paletteColors.ball;
     ctx.beginPath();
     ctx.arc(ball.x, ball.y, ball.radius, 0, Math.PI * 2);
     ctx.fill();

--- a/public/index.html
+++ b/public/index.html
@@ -33,6 +33,7 @@
         </div>
         <div id="controls">Click to add a block. Press 'r' for a new puzzle.
             <button id="resetLevelBtn">Reset Level</button>
+            <button id="settingsBtn">Settings</button>
         </div>
     </div>
     <div id="tutorial" class="modal">
@@ -40,6 +41,20 @@
             <h2>Welcome!</h2>
             <p>Use <strong>R/F</strong> to rotate ramps, <strong>Delete</strong> to remove a piece and <strong>Space</strong> to start or stop a test run.</p>
             <button id="skipTutorialBtn">Start Playing</button>
+        </div>
+    </div>
+    <div id="settingsModal" class="modal hidden">
+        <div class="settings-content">
+            <h2>Settings</h2>
+            <label>Volume:
+                <input id="volumeSlider" type="range" min="0" max="1" step="0.01" />
+            </label>
+            <br>
+            <label>
+                <input type="checkbox" id="colorBlindToggle" /> Color blind palette
+            </label>
+            <br>
+            <button id="closeSettingsBtn">Close</button>
         </div>
     </div>
     <script type="module" src="client.js"></script>

--- a/public/sound.js
+++ b/public/sound.js
@@ -1,11 +1,16 @@
 export const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+export let masterVolume = 1;
+
+export function setMasterVolume(v) {
+    masterVolume = Math.max(0, Math.min(1, v));
+}
 
 export function playBeep(freq = 440, duration = 0.1, volume = 0.1) {
     const osc = audioCtx.createOscillator();
     const gain = audioCtx.createGain();
     osc.type = 'sine';
     osc.frequency.value = freq;
-    gain.gain.value = volume;
+    gain.gain.value = volume * masterVolume;
     osc.connect(gain);
     gain.connect(audioCtx.destination);
     osc.start();
@@ -21,8 +26,8 @@ export function startBackgroundMusic() {
         const gain = audioCtx.createGain();
         osc.type = 'sine';
         osc.frequency.value = freq;
-        gain.gain.setValueAtTime(0.05, audioCtx.currentTime);
-        gain.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.4);
+        gain.gain.setValueAtTime(0.05 * masterVolume, audioCtx.currentTime);
+        gain.gain.exponentialRampToValueAtTime(0.001 * masterVolume, audioCtx.currentTime + 0.4);
         osc.connect(gain);
         gain.connect(audioCtx.destination);
         osc.start();

--- a/public/style.css
+++ b/public/style.css
@@ -141,8 +141,8 @@ input:focus {
     outline: 2px solid #6cf;
 }
 
-/* Tutorial overlay */
-#tutorial {
+/* Modal overlays */
+.modal {
     position: absolute;
     top: 0;
     left: 0;
@@ -155,11 +155,19 @@ input:focus {
     pointer-events: auto;
 }
 
-#tutorial.hidden {
+.modal.hidden {
     display: none;
 }
 
+/* Tutorial overlay */
 #tutorial .tutorial-content {
+    background: #222;
+    padding: 20px;
+    border-radius: 8px;
+    text-align: center;
+}
+
+#settingsModal .settings-content {
     background: #222;
     padding: 20px;
     border-radius: 8px;


### PR DESCRIPTION
## Summary
- create settings modal UI with volume slider and color-blind palette toggle
- store master volume and color palette on the client
- hook up event listeners to change audio volume and palette
- expose master volume in sound module
- mark TODO item complete

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dd2fa5b20832fa8cd64fb36397cef