### PR TITLE
Improve canvas scaling for varied screen heights

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -158,7 +158,12 @@ function coordsFromEvent(e) {
     const rect = canvas.getBoundingClientRect();
     const clientX = e.touches ? e.touches[0].clientX : e.clientX;
     const clientY = e.touches ? e.touches[0].clientY : e.clientY;
-    return { x: clientX - rect.left, y: clientY - rect.top };
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    return {
+        x: (clientX - rect.left) * scaleX,
+        y: (clientY - rect.top) * scaleY
+    };
 }
 
 function rotateHandlePos(p) {

--- a/public/ui.js
+++ b/public/ui.js
@@ -13,10 +13,16 @@ export function pieceAlpha(piece, duration = 300) {
     return Math.min(age / duration, 1);
 }
 
-export function setupResponsiveCanvas(canvas) {
+export function setupResponsiveCanvas(canvas, baseWidth = 800, baseHeight = 600) {
+    if (!canvas.style) canvas.style = {};
     function resize() {
-        canvas.width = window.innerWidth;
-        canvas.height = window.innerHeight;
+        const scaleX = window.innerWidth / baseWidth;
+        const scaleY = window.innerHeight / baseHeight;
+        const scale = Math.min(scaleX, scaleY);
+        canvas.width = baseWidth;
+        canvas.height = baseHeight;
+        canvas.style.transformOrigin = 'top left';
+        canvas.style.transform = `scale(${scale})`;
     }
     resize();
     window.addEventListener('resize', resize);

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -9,15 +9,16 @@ test('side view remains enabled', () => {
   assert.equal(sideView, true);
 });
 
-test('setupResponsiveCanvas adjusts size', () => {
-  const canvas = {};
+test('setupResponsiveCanvas applies scaling', () => {
+  const canvas = { style: {} };
   global.window = {
     innerWidth: 500,
     innerHeight: 400,
     addEventListener: (_, fn) => fn()
   };
-  setupResponsiveCanvas(canvas);
-  assert.equal(canvas.width, 500);
-  assert.equal(canvas.height, 400);
+  setupResponsiveCanvas(canvas, 800, 600);
+  assert.equal(canvas.width, 800);
+  assert.equal(canvas.height, 600);
+  assert.ok(canvas.style.transform.startsWith('scale('));
   delete global.window;
 });


### PR DESCRIPTION
## Summary
- update `setupResponsiveCanvas` to scale the canvas instead of resizing it
- adjust pointer coordinate conversion for scaled canvas
- update tests for new scaling logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687176369698832f9be27646eed59f93